### PR TITLE
Double processes and increase timeouts to 10 minutes.

### DIFF
--- a/uwsgi-config.ini
+++ b/uwsgi-config.ini
@@ -8,5 +8,8 @@
 wsgi-file   = ./bin/api.wsgi
 master      = True
 die-on-term = True
-processes   = 4
+processes   = 8
 threads     = 2
+http-timeout = 600
+socket-timeout = 600
+harakiri    = 600


### PR DESCRIPTION
This should use more resources but fail downloads less.