### PR TITLE
Prevent empty files from corrupting download archives.

### DIFF
--- a/api/download.py
+++ b/api/download.py
@@ -193,6 +193,7 @@ class Download(base.RequestHandler):
             for filepath, arcpath, _ in ticket['target']:
                 yield archive.gettarinfo(filepath, arcpath).tobuf()
                 with open(filepath, 'rb') as fd:
+                    chunk = ''
                     for chunk in iter(lambda: fd.read(CHUNKSIZE), ''):
                         yield chunk
                     if len(chunk) % BLOCKSIZE != 0:


### PR DESCRIPTION
`chunk` variable is reused from the previous file, corrupting archives.

Fixes https://github.com/OpenNeuroOrg/openneuro/issues/562