### PR TITLE
Catch the exception triggered by no ORCID primary email value.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ VOLUME /srv/bids-core/logs
 
 # Install pip modules
 RUN pip install --upgrade pip wheel setuptools \
-  && pip install -r /srv/bids-core/requirements.txt \
+  && pip install --ignore-installed -r /srv/bids-core/requirements.txt \
   && pip install -r requirements_dev.txt
 
 EXPOSE 8112

--- a/api/auth/provider.py
+++ b/api/auth/provider.py
@@ -48,7 +48,11 @@ def orcid(access_token):
         emails = doc.children[0].person_person.email_emails
         if hasattr(emails, 'email_email'):
             if type(emails.email_email) == list:
-                email = next(e.email_email.cdata for e in emails.email_email if e['primary'] == 'true')
+                try:
+                    email = next(e.email_email.cdata for e in emails.email_email if e['primary'] == 'true')
+                except StopIteration:
+                    # No public primary email set
+                    return
             else:
                 email = emails.email_email.email_email.cdata
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ enum==0.4.6
 jsonschema==2.5.1
 Markdown==2.6.5
 pymongo==3.2
-pyOpenSSL==0.15.1
+pyOpenSSL==17.5.0
 python-dateutil==2.4.2
 pytz==2015.7
 requests==2.9.1


### PR DESCRIPTION
If a user tries to login with ORCID and their primary email is not public (but they do have one public email) they will run into this exception. This catches the exception and allows OpenNeuro to return a sensible error message.

See https://github.com/OpenNeuroOrg/openneuro/issues/597